### PR TITLE
Don't require all env vars to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,20 @@ remote help
 
  ⚠️  You must set the following ENV VARS:
  INSTANCE_NAME            - The name of the instance (e.g. datascience_base)
- FILTER_PREFIX            - The prefix used to identify instances of interest 
-                            (e.g. datascience)
+
+ To make use of remote list you can optionally set:
+ FILTER_PREFIX            - The prefix used to identify instances
+                            of interest (e.g. datascience)
+
+ Optionally you can also set the following if you intend to use
+ the remote git command
  REMOTE_PATH              - Path to remote working repo
  LOCAL_PATH               - Path to local working repo
- AWS_ACCESS_KEY_ID        - AWS access key ID
- AWS_SECRET_ACCESS_KEY_ID - AWS secret key
+
+ ⚠️  You must also have your AWS credentials set either locally
+ as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY_ID or as
+ AWS_PROFILE, having first set your credentials with aws, usually
+ in ~/.aws/credentials and ~/.aws/config.
 
  ⚠️  All commands will filter terminated instances by default
 
@@ -35,19 +43,21 @@ remote help
            argument \(e.g. t2.small\), otherwise returns the
            instance type
  stop    - Stops the instance
+
+
 ```
 
 ## Env Variables
 
 The following ENV vars must be set in your local env for this script to run correctly:
 
-|ENV VAR|explanataion|Nominal value|
-|---|---|---|
-|INSTANCE_NAME|Name of the instance you wish to communicate with. Note that this requires that the tag `Name` is set on the instance of interest|datascience_base|
-|FILTER_PREFIX|Prefix used to identify instances for a given task|datascience|
-|REMOTE_PATH|Path to remote working repository|/data/datalabs|
-|LOCAL_PATH|Path to local working repository|~/datalabs|
-|AWS_ACCESS_KEY_ID|AWS credentials||
-|AWS_SECRET_ACCESS_KEY|AWS credentials||
+|ENV VAR|explanataion|Nominal value|Required?|
+|---|---|---|---|
+|INSTANCE_NAME|Name of the instance you wish to communicate with. Note that this requires that the tag `Name` is set on the instance of interest|datascience_base|Yes|
+|FILTER_PREFIX|Prefix used to identify instances for a given task|datascience|for `remote list`|
+|REMOTE_PATH|Path to remote working repository|/data/datalabs|for `remote git`|
+|LOCAL_PATH|Path to local working repository|~/datalabs|for `remtoe git`|
+
+NOTE: You must also have permission to control ec2 instances either by setting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or by setting AWS_PROFILE and creating a corresponding profile in `~/.aws/config` and `~/.aws/credentials`.
 
 

--- a/remote
+++ b/remote
@@ -3,12 +3,7 @@
 
 # Check whether credentials are set
 
-: "${AWS_ACCESS_KEY_ID:?}"
-: "${AWS_SECRET_ACCESS_KEY:?}"
-: "${REMOTE_PATH:?"You must set REMOTE_PATH to point at the remote working repo."}"
-: "${LOCAL_PATH:?"You must set LOCAL_PATH to point at the local working repo."}"
 : "${INSTANCE_NAME:?"You must set the name of your ec2 instance, e.g. datascience_mattupson"}"
-: "${FILTER_PREFIX:?"You must set the prefic used to identify your instances, e.g. datascience"}"
 
 WARN=⚠️
 BOOM=💥
@@ -47,13 +42,13 @@ function remote {
             echo -e "$STRONG $GREEN Instance $BLUE$INSTANCE_NAME$GREEN started$WHITE"
 
     #
-    # Create an ec2 remote in your local datalabs folder
+    # Create an ec2 remote in your local repo
     #
 
     elif [[ "$1" == 'git' ]]; then
 
-        : "${REMOTE_PATH:?"You must set the path to the datalabs folder on the remote (usually /data/datalabs)"}"
-        : "${LOCAL_PATH:?"You must set the path to your local datalabs folder on the remote (usually /data/datalabs)"}"
+        : "${REMOTE_PATH:?"You must set the path to the remote working repo."}"
+        : "${LOCAL_PATH:?"You must set the path to the local working repo."}"
 
         INSTANCE_IP=$(aws ec2 describe-instances --filters \
         "Name=tag:Name,Values=$INSTANCE_NAME" \
@@ -154,7 +149,9 @@ function remote {
 
     elif [[ "$1" == 'list' ]]; then
 
-        echo -e "$WAIT Getting list of all datalabs instances"
+        : "${FILTER_PREFIX:?"You must set a prefix by which to filter instances."}"
+
+        echo -e "$WAIT Getting list of all instances that match $FILTER_PREFIX"
 
         aws ec2 describe-instances --output table \
         --filters "Name=tag:Name,Values=*$FILTER_PREFIX*" \
@@ -265,12 +262,20 @@ function remote {
         echo ""
         echo " $WARN  You must set the following ENV VARS:"
         echo " INSTANCE_NAME            - The name of the instance (e.g. datascience_base)"
+        echo ""
+        echo " To make use of remote list you can optionally set:"
         echo " FILTER_PREFIX            - The prefix used to identify instances"
         echo "                            of interest (e.g. datascience)"
+        echo ""
+        echo " Optionally you can also set the following if you intend to use"
+        echo " the remote git command"
         echo " REMOTE_PATH              - Path to remote working repo"
         echo " LOCAL_PATH               - Path to local working repo"
-        echo " AWS_ACCESS_KEY_ID        - AWS access key ID"
-        echo " AWS_SECRET_ACCESS_KEY_ID - AWS secret key"
+        echo ""
+        echo " $WARN  You must also have your AWS credentials set either locally"
+        echo " as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY_ID or as"
+        echo " AWS_PROFILE, having first set your credentials with aws, usually"
+        echo " in ~/.aws/credentials and ~/.aws/config."
         echo ""
         echo " $WARN  All commands will filter terminated instances by default"
         echo ""


### PR DESCRIPTION
#### Rationale
Not everyone wants to set their AWS credentials as env vars, some users will allow the AWS credentials to be set by awscli, and instead set the `AWS_PROFILE` env var (if required). This update changes these env vars to optional, in addition to `LOCAL_PATH` and `REMOTE_PATH` which are only required for `remote git` and `FILTER_PREFIX` which is only required for `remote list`.