### PR TITLE
Add instances command

### DIFF
--- a/remote
+++ b/remote
@@ -264,7 +264,8 @@ function remote {
 
         aws ec2 describe-instance-types \
             --output table \
-            --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus,GPUs:GpuInfo.Gpus[0].Count}"
+            --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus,GPUs:GpuInfo.Gpus[0].Count}" \
+            --filters "Name=instance-type,Values=p*,c*,m*"
 
     else
 

--- a/remote
+++ b/remote
@@ -256,6 +256,16 @@ function remote {
 
         aws ec2 stop-instances --instance-ids $INSTANCE_ID
 
+    #
+    # List instance types
+    #
+
+    elif [[ "$1" == 'list-instances' ]]; then
+
+        aws ec2 describe-instance-types \
+            --output table \
+            --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus}"
+
     else
 
         echo -e "$BLUE $ZAP AWS EC2 instance remote control $ZAP"
@@ -281,21 +291,22 @@ function remote {
         echo ""
         echo " $STRONG Available commands:"
         echo ""
-        echo " start   - Starts the instance"
-        echo " git     - Sets up a remote in your local datalabs repo that "
-        echo "           points to the remote repo on the instance. This "
-        echo "           allows you to push code directly to your instance "
-        echo "           from your local datalabs folder with git push ec2"
-        echo " connect - Tries to connect to the instance"
-        echo " id      - Returns the instance id e.g. i-ae23f836a5f3de"
-        echo " ip      - Returns the instance public address ec2-x-x-x-x...amazonaws.com"
-        echo " status  - Returns the status of the instance"
-        echo " list    - Lists all the ec2 instances whose name has a prefix"
-        echo "           described by FILTER_PREFIX."
-        echo " type    - Changes the instance type to that specified as an"
-        echo "           argument \(e.g. t2.small\), otherwise returns the"
-        echo "           instance type"
-        echo " stop    - Stops the instance"
+        echo " start           - Starts the instance"
+        echo " git             - Sets up a remote in your local datalabs repo that "
+        echo "                   points to the remote repo on the instance. This "
+        echo "                   allows you to push code directly to your instance "
+        echo "                   from your local datalabs folder with git push ec2"
+        echo " connect         - Tries to connect to the instance"
+        echo " id              - Returns the instance id e.g. i-ae23f836a5f3de"
+        echo " ip              - Returns the instance public address ec2-x-x-x-x...amazonaws.com"
+        echo " status          - Returns the status of the instance"
+        echo " list            - Lists all the ec2 instances whose name has a prefix"
+        echo "                   described by FILTER_PREFIX."
+        echo " type            - Changes the instance type to that specified as an"
+        echo "                   argument \(e.g. t2.small\), otherwise returns the"
+        echo "                   instance type"
+        echo " stop            - Stops the instance"
+        echo " list-instances  - Lists information about available ec2 instances"
         echo ""
 
     fi

--- a/remote
+++ b/remote
@@ -261,11 +261,15 @@ function remote {
     #
 
     elif [[ "$1" == 'instances' ]]; then
-
+        if [[ "$2" ]]; then
+            FILTER_INSTANCES="$2"
+        else
+            FILTER_INSTANCES=c*,p*,r*
+        fi
         aws ec2 describe-instance-types \
             --output table \
             --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus,GPUs:GpuInfo.Gpus[0].Count}" \
-            --filters "Name=instance-type,Values=p*,c*,m*"
+            --filters "Name=instance-type,Values=$FILTER_INSTANCES"
 
     else
 
@@ -308,6 +312,8 @@ function remote {
         echo "                   instance type"
         echo " stop            - Stops the instance"
         echo " instances       - Lists information about available ec2 instances"
+        echo "                   by default filter c*,p*,r* but custom filter can"
+        echo "                   be passed as second argument e.g. r4\*"
         echo ""
 
     fi

--- a/remote
+++ b/remote
@@ -264,7 +264,7 @@ function remote {
 
         aws ec2 describe-instance-types \
             --output table \
-            --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus}"
+            --query "InstanceTypes[].{Instance:InstanceType,Memory:MemoryInfo.SizeInMiB,vCPUs:VCpuInfo.DefaultVCpus,GPUs:GpuInfo.Gpus[0].Count}"
 
     else
 

--- a/remote
+++ b/remote
@@ -260,7 +260,7 @@ function remote {
     # List instance types
     #
 
-    elif [[ "$1" == 'list-instances' ]]; then
+    elif [[ "$1" == 'instances' ]]; then
 
         aws ec2 describe-instance-types \
             --output table \
@@ -306,7 +306,7 @@ function remote {
         echo "                   argument \(e.g. t2.small\), otherwise returns the"
         echo "                   instance type"
         echo " stop            - Stops the instance"
-        echo " list-instances  - Lists information about available ec2 instances"
+        echo " instances       - Lists information about available ec2 instances"
         echo ""
 
     fi


### PR DESCRIPTION
**TODO**: Update https://github.com/wellcometrust/datalabs/wiki/Using-EC2 when merged

Fixes #11 

Adds `list-instances` command that outputs

```
-----------------------------------------------
|            DescribeInstanceTypes            |
+------+-----------------+----------+---------+
| GPUs |    Instance     | Memory   |  vCPUs  |
+------+-----------------+----------+---------+
|  None|  m6g.xlarge     |  16384   |  4      |
|  None|  m5.8xlarge     |  131072  |  32     |
|  None|  m5a.2xlarge    |  32768   |  8      |
|  None|  c3.large       |  3840    |  2      |
|  None|  c6gd.metal     |  131072  |  64     |
|  8   |  g4dn.metal     |  393216  |  96     |
```

Some discussion points @ivyleavedtoadflax @aCampello 
* currently this command lists all instances (more than 300), should we filter for only those we more commonly use like c,r and p instances? **Update**: Implemented that
* the name of the command is list-instances which is a bit similar to list, is there an alternative name or a way to make list and list-instances differentiate better? **Update**: Renamed to instances
* do we want additional information? **Update**: For price I added a new issue #13 as I have not found a way to add the information