### PR TITLE
chg: Add ls alias for list (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 A script to make managing EC2 instances easier.
 
 ```
-remote help
-
  ⚡ AWS EC2 instance remote control ⚡
 
  ⚠️  You must set the following ENV VARS:
@@ -28,22 +26,24 @@ remote help
 
  💪 Available commands:
 
- start   - Starts the instance
- git     - Sets up a remote in your local datalabs repo that 
-           points to the remote repo on the instance. This 
-           allows you to push code directly to your instance 
-           from your local datalabs folder with git push ec2
- connect - Tries to connect to the instance
- id      - Returns the instance id e.g. i-ae23f836a5f3de
- ip      - Returns the instance public address ec2-x-x-x-x...amazonaws.com
- status  - Returns the status of the instance
- list    - Lists all the ec2 instances whose name has a prefix
-           described by FILTER_PREFIX.
- type    - Changes the instance type to that specified as an
-           argument \(e.g. t2.small\), otherwise returns the
-           instance type
- stop    - Stops the instance
-
+ start           - Starts the instance
+ git             - Sets up a remote in your local datalabs repo that 
+                   points to the remote repo on the instance. This 
+                   allows you to push code directly to your instance 
+                   from your local datalabs folder with git push ec2
+ connect         - Tries to connect to the instance
+ id              - Returns the instance id e.g. i-ae23f836a5f3de
+ ip              - Returns the instance public address ec2-x-x-x-x...amazonaws.com
+ status          - Returns the status of the instance
+ list | ls       - Lists all the ec2 instances whose name has a prefix
+                   described by FILTER_PREFIX.
+ type            - Changes the instance type to that specified as an
+                   argument \(e.g. t2.small\), otherwise returns the
+                   instance type
+ stop            - Stops the instance
+ instances       - Lists information about available ec2 instances
+                   by default filter c*,p*,r* but custom filter can
+                   be passed as second argument e.g. r4\*
 
 ```
 

--- a/remote
+++ b/remote
@@ -147,7 +147,7 @@ function remote {
     # List all datalabs instances
     #
 
-    elif [[ "$1" == 'list' ]]; then
+    elif [[ "$1" =~ 'list' ]] || [[ "$1" =~ 'ls' ]]; then
 
         : "${FILTER_PREFIX:?"You must set a prefix by which to filter instances."}"
 
@@ -305,7 +305,7 @@ function remote {
         echo " id              - Returns the instance id e.g. i-ae23f836a5f3de"
         echo " ip              - Returns the instance public address ec2-x-x-x-x...amazonaws.com"
         echo " status          - Returns the status of the instance"
-        echo " list            - Lists all the ec2 instances whose name has a prefix"
+        echo " list | ls       - Lists all the ec2 instances whose name has a prefix"
         echo "                   described by FILTER_PREFIX."
         echo " type            - Changes the instance type to that specified as an"
         echo "                   argument \(e.g. t2.small\), otherwise returns the"


### PR DESCRIPTION
Follows #17. Adds `ls` as an alias for `list`.