### PR TITLE
Add verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ remote help
  ⚠️  You must also have your AWS credentials set either locally
  as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY_ID or as
  AWS_PROFILE, having first set your credentials with aws, usually
- in ~/.aws/credentials and ~/.aws/config.
+ in ~/.aws/credentials and ~/.aws/config using `aws configure`.
 
  ⚠️  All commands will filter terminated instances by default
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ remote help
            instance type
  stop    - Stops the instance
 
+ 💪 Available options:
 
+ -v / --verbose  - Commands return verbose output
 ```
 
 ## Env Variables

--- a/remote
+++ b/remote
@@ -20,6 +20,12 @@ WHITE="\e[0m"
 
 function remote {
 
+    if [[ "$2" == '-v' ]] || [[ "$2" == '--verbose' ]]; then
+
+	VERBOSE=1
+
+    fi
+
     #
     # Start a stopped instance
     #
@@ -81,7 +87,7 @@ function remote {
     #
     
     elif [[ "$1" == 'connect' ]]; then
-    
+
         INSTANCE_IP=$(aws ec2 describe-instances --filters \
         "Name=tag:Name,Values=$INSTANCE_NAME" \
         "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" | \
@@ -111,7 +117,11 @@ function remote {
           "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" | \
           jq -r ".Reservations[] | .Instances[] | .InstanceId")
 
-        echo -e "$DONE  $BLUE$INSTANCE_NAME$WHITE instance id: $BLUE$INSTANCE_ID$WHITE"
+	    if [[ $VERBOSE ]]; then
+                echo -e "$DONE  $BLUE$INSTANCE_NAME$WHITE instance id: $BLUE$INSTANCE_ID$WHITE"
+	    else
+            	echo -e "$INSTANCE_ID"
+	    fi
 
     #
     # Return the instance IP
@@ -119,12 +129,16 @@ function remote {
 
     elif [[ "$1" == 'ip' ]]; then
 
-        INSTANCE_ID=$(aws ec2 describe-instances \
+        INSTANCE_IP=$(aws ec2 describe-instances \
           --filters "Name=tag:Name,Values=$INSTANCE_NAME" \
           "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" | \
           jq -r ".Reservations[] | .Instances[] | .PublicDnsName")
 
-        echo -e "$DONE  $BLUE$INSTANCE_NAME$WHITE instance ip: $BLUE$INSTANCE_ID$WHITE"
+	    if [[ $VERBOSE ]]; then
+            	echo -e "$DONE  $BLUE$INSTANCE_NAME$WHITE instance ip: $BLUE$INSTANCE_IP$WHITE"
+	    else
+            	echo -e "$INSTANCE_IP"
+	    fi
 
     #
     # Get the instance status
@@ -314,6 +328,10 @@ function remote {
         echo " instances       - Lists information about available ec2 instances"
         echo "                   by default filter c*,p*,r* but custom filter can"
         echo "                   be passed as second argument e.g. r4\*"
+        echo ""
+        echo " $STRONG Available options:"
+        echo ""
+        echo " -v / --verbose  - Commands return verbose output"
         echo ""
 
     fi

--- a/remote
+++ b/remote
@@ -96,8 +96,15 @@ function remote {
         n=0
         until [ $n -ge 5 ]
         do
-            ssh ubuntu@$INSTANCE_IP && break || \
-                echo -e "$WARN $RED Connection failed, trying again $[5-$n] times.$WHITE" 
+
+
+	        if [[ $VERBOSE ]]; then
+                ssh -v ubuntu@$INSTANCE_IP && break || \
+                    echo -e "$WARN $RED Connection failed, trying again $[5-$n] times.$WHITE" 
+	        else
+                ssh ubuntu@$INSTANCE_IP && break || \
+                    echo -e "$WARN $RED Connection failed, trying again $[5-$n] times.$WHITE" 
+	        fi
             n=$[$n+1]
             if [[ "$n" = 5 ]]; then 
                 echo -e "$WARN $RED Could not connect to instance $BLUE$INSTANCE_NAME$WHITE."


### PR DESCRIPTION
Often it is very useful to be able to pass `$(remote id)` to a command, for example:

```
aws ec2 terminate-instance --instance-ids $(remote id)
```

This update changes the default behaviour of the `id` and `ip` commands so by default they return the output simply in a way that can be re-used as in the example above. If passed with `-v` or `--verbose`, a more verbose output is returned which matches the current default behaviour without the `-v` flag.