### PR TITLE
Implements job stop

### DIFF
--- a/remote
+++ b/remote
@@ -296,10 +296,10 @@ function remote {
 		if [[ "$2" == 'stop' ]]; then
 			if [[ "$3" ]]; then
 				JOB_NAME=$(aws sagemaker list-training-jobs --status-equals "InProgress" --name-contains "$3" --max-items 1 | \
-					jq '.TrainingJobSummaries[].TrainingJobName')
+					jq -r '.TrainingJobSummaries[].TrainingJobName')
 			else
 				JOB_NAME=$(aws sagemaker list-training-jobs --status-equals "InProgress" --max-items 1 | \
-					jq '.TrainingJobSummaries[].TrainingJobName')
+					jq -r '.TrainingJobSummaries[].TrainingJobName')
 			fi
 			aws sagemaker stop-training-job --training-job-name "$JOB_NAME"
 		else

--- a/remote
+++ b/remote
@@ -293,10 +293,20 @@ function remote {
             --filters "Name=instance-type,Values=$FILTER_INSTANCES"
 
 	elif [[ "$1" == 'jobs' ]]; then
-		aws sagemaker list-training-jobs \
-			--output table \
-			--query "TrainingJobSummaries[:10].{JobName:TrainingJobName,Status:TrainingJobStatus}"
-
+		if [[ "$2" == 'stop' ]]; then
+			if [[ "$3" ]]; then
+				JOB_NAME=$(aws sagemaker list-training-jobs --status-equals "InProgress" --name-contains "$3" --max-items 1 | \
+					jq '.TrainingJobSummaries[].TrainingJobName')
+			else
+				JOB_NAME=$(aws sagemaker list-training-jobs --status-equals "InProgress" --max-items 1 | \
+					jq '.TrainingJobSummaries[].TrainingJobName')
+			fi
+			aws sagemaker stop-training-job --training-job-name "$JOB_NAME"
+		else
+			aws sagemaker list-training-jobs \
+				--output table \
+				--query "TrainingJobSummaries[:10].{JobName:TrainingJobName,Status:TrainingJobStatus}"
+		fi
     else
 
         echo -e "$BLUE $ZAP AWS EC2 instance remote control $ZAP"
@@ -322,25 +332,26 @@ function remote {
         echo ""
         echo " $STRONG Available commands:"
         echo ""
-        echo " start           - Starts the instance"
-        echo " git             - Sets up a remote in your local datalabs repo that "
-        echo "                   points to the remote repo on the instance. This "
-        echo "                   allows you to push code directly to your instance "
-        echo "                   from your local datalabs folder with git push ec2"
-        echo " connect         - Tries to connect to the instance"
-        echo " id              - Returns the instance id e.g. i-ae23f836a5f3de"
-        echo " ip              - Returns the instance public address ec2-x-x-x-x...amazonaws.com"
-        echo " status          - Returns the status of the instance"
-        echo " list | ls       - Lists all the ec2 instances whose name has a prefix"
-        echo "                   described by FILTER_PREFIX."
-        echo " type            - Changes the instance type to that specified as an"
-        echo "                   argument \(e.g. t2.small\), otherwise returns the"
-        echo "                   instance type"
-        echo " stop            - Stops the instance"
-        echo " instances       - Lists information about available ec2 instances"
-        echo "                   by default filter c*,p*,r* but custom filter can"
-        echo "                   be passed as second argument e.g. r4\*"
-        echo " jobs            - Lists sagemaker jobs and their progress"
+        echo " start               - Starts the instance"
+        echo " git                 - Sets up a remote in your local datalabs repo that "
+        echo "                       points to the remote repo on the instance. This "
+        echo "                       allows you to push code directly to your instance "
+        echo "                       from your local datalabs folder with git push ec2"
+        echo " connect             - Tries to connect to the instance"
+        echo " id                  - Returns the instance id e.g. i-ae23f836a5f3de"
+        echo " ip                  - Returns the instance public address ec2-x-x-x-x...amazonaws.com"
+        echo " status              - Returns the status of the instance"
+        echo " list | ls           - Lists all the ec2 instances whose name has a prefix"
+        echo "                       described by FILTER_PREFIX."
+        echo " type                - Changes the instance type to that specified as an"
+        echo "                       argument \(e.g. t2.small\), otherwise returns the"
+        echo "                       instance type"
+        echo " stop                - Stops the instance"
+        echo " instances           - Lists information about available ec2 instances"
+        echo "                       by default filter c*,p*,r* but custom filter can"
+        echo "                       be passed as second argument e.g. r4\*"
+        echo " jobs                - Lists sagemaker jobs and their progress"
+		echo " jobs stop JOB_NAME  - Stops sagemaker jobs that starts with JOB_NAME"
 		echo ""
         echo " $STRONG Available options:"
         echo ""
@@ -350,4 +361,4 @@ function remote {
     fi
 }
 
-remote $1 $2
+remote $1 $2 $3


### PR DESCRIPTION
Implements `remote jobs stop JOB_NAME` to be able to terminate a sagemaker job from remote.

* If JOB_NAME is omitted it terminates the last in progress job started.
* JOB_NAME does not need to be the full name as sagemaker jobs tend to be long, someone can do `remote jobs stop mesh`

Fixes #27 
