### PR TITLE
Fix Price

### DIFF
--- a/remote
+++ b/remote
@@ -329,13 +329,13 @@ function remote {
 				--query "TrainingJobSummaries[:10].{JobName:TrainingJobName,Status:TrainingJobStatus}"
 		fi
 	elif [[ "$1" == 'price' ]]; then
-        INSTANCE_TYPE=$2
+        INSTANCE_TYPE=${2//./_}
         AMOUNT=$(curl -s \
             --request GET \
             --url https://api.vantage.sh/v1/products/aws-ec2-$INSTANCE_TYPE/prices/aws-ec2-$INSTANCE_TYPE-eu_west_1-on_demand-linux \
             --header 'Accept: application/json' \
             --header 'Authorization: Bearer sd4QN9r9YuOEAUqtZ75xz2dvHFQf7i_4EU1Wql3gih0' | jq -r '.amount')
-		echo "Instance $INSTANCE_TYPE costs $AMOUNT\$ per hour"
+		echo "Instance $INSTANCE_TYPE costs $ $AMOUNT (USD) per hour"
 	else
         echo -e "$BLUE $ZAP AWS EC2 instance remote control $ZAP"
         echo ""


### PR DESCRIPTION
Rationale: the Vantage API now requires you to type `r4_xlarge` instead of `r4.xlarge` (i.e. with underscores)